### PR TITLE
Update dlt dependency to version 1.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,11 @@ packages = [{include = "sources"}]
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.13"
-dlt = {version = "1.3.0", allow-prereleases = true, extras = ["redshift", "bigquery", "postgres", "duckdb"]}
+dlt = {version = "1.5.0", allow-prereleases = true, extras = ["redshift", "bigquery", "postgres", "duckdb"]}
 graphlib-backport = {version = "*", python = "<3.9"}
 
 [tool.poetry.group.dltpure.dependencies]
-dlt = {version = "1.3.0", allow-prereleases = true}
+dlt = {version = "1.5.0", allow-prereleases = true}
 
 [tool.poetry.group.pytest.dependencies]
 pytest = "^7.2.0"


### PR DESCRIPTION
### Tell us what you do here
- updating dependencies

### Short description
Upgraded the `dlt` library from version 1.3.0 to 1.5.0 to ensure access to the latest features and improvements, while maintaining compatibility with the specified extras.
