### PR TITLE
Switch DEFAULT_STATS_FIELDS from list to tuple

### DIFF
--- a/sources/seznam_sklik/settings.py
+++ b/sources/seznam_sklik/settings.py
@@ -2,7 +2,7 @@
 
 SKLIK_DATA_FORMAT = "YYYYMMDD"
 
-DEFAULT_STATS_FIELDS = [
+DEFAULT_STATS_FIELDS = (
     "id",
     "name",
     "type",
@@ -13,7 +13,7 @@ DEFAULT_STATS_FIELDS = [
     "conversions",
     "conversionValue",
     "totalMoney"
-]
+)
 
 DEFAULT_STATS_FILTER = {}
 


### PR DESCRIPTION
### Tell us what you do here
- improving, documenting, or customizing an existing source (please link an issue or describe below)

### Short description
Changed `DEFAULT_STATS_FIELDS` to a tuple to enhance immutability and better align with its intended use as a constant.

### Related Issues
- None

### Additional Context
Ensure tests have been run, and contributors have read the contributing guide.