### PR TITLE
Simplify default stats configuration

### DIFF
--- a/sources/rtbhouse/settings.py
+++ b/sources/rtbhouse/settings.py
@@ -1,10 +1,3 @@
 """RTBHouse source settings and constants"""
-from rtbhouse_sdk.schema import StatsMetric
 
-DEFAULT_STATS = (
-    StatsMetric.IMPS_COUNT,
-    StatsMetric.CLICKS_COUNT,
-    StatsMetric.CONVERSIONS_COUNT,
-    StatsMetric.CONVERSIONS_VALUE,
-    StatsMetric.CAMPAIGN_COST,
-)
+DEFAULT_STATS = ()


### PR DESCRIPTION
### Tell us what you do here
- improving, documenting, or customizing an existing source (please link an issue or describe below)

### Short description
This pull request removes predefined metrics from `DEFAULT_STATS`, enabling greater flexibility to dynamically or externally define stats metrics as needed. 

